### PR TITLE
.gitignore: Add *.orig

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,5 +1,5 @@
 [Default]
-bears = IndentBear,LineLengthBear,SpaceConsistencyBear
+bears = GNUIndentBear,LineLengthBear,SpaceConsistencyBear
 max_line_length = 99
 use_spaces = True
 

--- a/.coafile
+++ b/.coafile
@@ -6,6 +6,7 @@ use_spaces = True
 [Python]
 bears=PEP8Bear,PyCommentedCodeBear,PyImportSortBear,PyLintBear,PyUnusedCodeBear
 files = **/*.py
+pylint_disable = C0411  # Import order is done by the PyImportSortBear
 
 [Docker]
 bears= DockerfileLintBear

--- a/.coafile
+++ b/.coafile
@@ -19,3 +19,8 @@ files = **/*.md
 [JSON]
 bears = JSONFormatBear
 files = **/*.json
+
+[Commits]
+bears = GitCommitBear
+# Trailing periods in shortlogs are evil!
+shortlog_trailing_period = False

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ repo*.sh
 *pycache
 *expect*.conf
 *.log
+*.orig


### PR DESCRIPTION
Those files will sometimes be created by git, sometimes by coala
and are used for backup purposes when automatic corrections are
applied (coala) or conflicts appear (git).